### PR TITLE
feat: markview strict_render, table math, unified templates, backlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 - **☑️ Task Checklists**: Easily toggle markdown checkbox items (`- [ ]` / `- [x]`) using `<leader>nt` (buffer-local, fully customizable).
 - **🖼️ Portable Clipboard Image Pasting**: Paste images directly from your clipboard across Linux (X11 & Wayland), macOS, and Windows. Saves files into `notes_dir/images/` and links them with portable relative paths (`images/image.png`).
 - **🔍 Telescope Integration**: Fuzzy find notes by title/tags/date via a clean column-based Telescope list (`:Notes list`), or live grep inside note content (`:Notes search`).
+- **🧮 Markdown Table Math**: Excel-like cell calculation (`=SUM(A1:A3)`, `=AVG(...)`, arithmetic operations) overlaid via non-destructive virtual text. Updates automatically on save and mode changes.
+- **📋 Dynamic Custom Templates**: Merges built-in Lua templates with your custom templates defined as files in `<notes_dir>/templates/`. All template files are excluded from core search, explorer, and autocompletion lists to keep your workspace clean.
 
 ---
 
@@ -97,6 +99,33 @@ When editing markdown files in your `notes_dir`, the plugin automatically activa
 * **Wiki-link Jump (`<CR>`)**: Press `<CR>` while cursor is on `[[Link]]` to navigate to that note.
 * **Task Toggle (`<leader>nt`)**: Toggle checklist state on the current line between `- [ ]` and `- [x]`.
 * **Highlight Toggle (`<leader>nh`)**: Highlight the selected text in visual mode or toggle highlighting on the word under the cursor using `==` tags.
+
+---
+
+## 🧮 Markdown Table Math
+
+`notes.nvim` features an automated Excel-like spreadsheet calculation engine for standard Markdown tables. Formula cells remain fully editable as standard text, and computed values are displayed as non-destructive virtual text next to the cell.
+
+### How it works:
+1. **Coordinate System**:
+   - Columns are lettered (`A`, `B`, `C`...) starting from the leftmost column in the table.
+   - Rows are numbered (`1`, `2`, `3`...) starting from the first data row (header and separator rows are skipped).
+2. **Formulas**:
+   - Begin with `=` (e.g., `=B1*C1`).
+   - Supported math functions: `SUM(range)`, `AVG(range)`, `COUNT(range)`, `MIN(range)`, `MAX(range)` (e.g. `=SUM(D1:D5)`).
+   - Basic arithmetic: `+`, `-`, `*`, `/`, parenthesis `()`, and numbers.
+3. **Execution**:
+   - Formulas evaluate automatically on `InsertLeave` and `BufWritePre` (when saving the file).
+   - Displays clear error hints on invalid inputs (e.g., `⚠️ circular` for circular dependencies, `⚠️ #DIV/0!` for division by zero, `⚠️ #VALUE!` for invalid calculations).
+
+#### Example:
+```markdown
+| Item   | Price | Qty | Total       |
+|--------|-------|-----|-------------|
+| Apple  | 10    | 3   | =B1*C1      |
+| Banana | 20    | 2   | =B2*C2      |
+| Total  |       |     | =SUM(D1:D2) |
+```
 
 ---
 
@@ -266,5 +295,55 @@ require("notes").setup({
 1. **Automatic Saves**: Whenever you write/save a note buffer within your `notes_dir`, the plugin automatically runs `git add -A` and `git commit -m "<commit_message>"` in the background.
 2. **File Operations**: Background commits are automatically generated for file actions that don't trigger normal buffer write events (e.g. deleting/renaming notes inside the explorer, saving a quick capture scratchpad, pasting images, and move operations).
 3. **No Network Activity**: The plugin only performs `git add` and `git commit` operations. It never performs remote network operations like `git push` or `git pull`, ensuring offline compatibility and speed.
+
+---
+
+## 📋 Note Templates
+
+`notes.nvim` provides a powerful note template engine. When creating a new note (via `:Notes new` or `n` in the explorer), a Telescope template picker lets you choose from pre-defined templates.
+
+### Dynamic Placeholders
+Within your templates, you can use the following standard placeholders which are resolved dynamically:
+- `%TITLE%`: The title of the note.
+- `%DATE%`: The current date formatted using `date_format`.
+- `%BODY%`: Default content or blank space.
+
+### 1. File-based Custom Templates
+You can create custom templates as standard Markdown files inside the `templates/` folder of your notes directory:
+- Path: `<notes_dir>/templates/<template-name>.md`
+- The name of the file (excluding `.md`) will appear in the template selection picker.
+- Any notes created from file-based templates are fully configured with standard YAML frontmatter.
+- **Hygiene & Filtering**: To keep your workspace clean, any files/folders inside the `templates/` directory are automatically excluded from the Notes Explorer sidebar, global Telescope note lists, live grep content searches, and autocompletion lists.
+
+### 2. Config-based Lua Templates
+You can also define templates in your Neovim config Lua setup function under the `templates` key:
+```lua
+require("notes").setup({
+  notes_dir = "~/.notes",
+  templates = {
+    custom_project = [[---
+title: "%TITLE%"
+date: "%DATE%"
+tags: ["project"]
+---
+# Project: %TITLE%
+- Task 1
+- Task 2
+]]
+  }
+})
+```
+
+#### Pre-defined Templates
+The plugin comes built-in with several standard templates:
+- `bug`: For bug reports and tracking.
+- `documentation`: For tech specs and library docs.
+- `job_application`: For tracking company applications.
+- `meeting`: For meeting minutes, agendas, and action items.
+- `release`: For application release notes.
+- `rfc`: For Request for Comments designs.
+- `til`: For "Today I Learned" quick learnings.
+- `daily`: Default template for daily journals.
+
 
 

--- a/lua/notes/config.lua
+++ b/lua/notes/config.lua
@@ -115,6 +115,73 @@ summary: ""
 
 ## References
 ]],
+		release = [[---
+title: "Release: %TITLE%"
+date: "%DATE%"
+tags: ["release"]
+summary: ""
+---
+
+# Release: %TITLE%
+
+## Overview
+
+## Added
+
+## Changed
+
+## Fixed
+
+## Removed
+
+## Deployment / Migration Notes
+]],
+		documentation = [[---
+title: "Documentation: %TITLE%"
+date: "%DATE%"
+tags: ["documentation"]
+summary: ""
+---
+
+# Documentation: %TITLE%
+
+## Overview
+
+## Usage / Quick Start
+
+## Architecture / Design
+
+## API Reference
+
+## Configuration
+
+## Examples
+]],
+		job_application = [[---
+title: "Job Application: %TITLE%"
+date: "%DATE%"
+tags: ["job-application", "career"]
+summary: ""
+---
+
+# Job Application: %TITLE%
+
+## Company Profile
+
+## Role / Job Description
+
+## Status
+- [ ] Applied
+- [ ] Technical Test
+- [ ] Interview
+- [ ] Offered / Rejected
+
+## Key Contacts
+
+## Notes / Preparation
+
+## Follow-up Timeline
+]],
 	},
 	keymaps = {
 		n = {
@@ -128,6 +195,7 @@ summary: ""
 			["<leader>nto"] = "outline",
 			["<leader>ntc"] = "insert_toc",
 			["<leader>ni"] = "choose_icon",
+			["<leader>nb"] = "backlinks",
 		},
 	},
 	key_desc = {

--- a/lua/notes/init.lua
+++ b/lua/notes/init.lua
@@ -128,6 +128,11 @@ M.setup = function(opts)
 
 			-- Configure omnifunc for wiki-link completion
 			vim.bo[ev.buf].omnifunc = "v:lua.require'notes.ui'.omnifunc"
+
+			-- Initial table math refresh
+			pcall(function()
+				require("notes.tablemath").refresh(ev.buf)
+			end)
 		end,
 	})
 
@@ -148,6 +153,23 @@ M.setup = function(opts)
 		end,
 	})
 
+	vim.api.nvim_create_autocmd("User", {
+		group = group,
+		pattern = "TelescopePreviewerLoaded",
+		callback = function(args)
+			if args and args.data and args.data.bufname then
+				local bufname = args.data.bufname
+				if bufname ~= "" then
+					local resolved_name = vim.fn.resolve(vim.fn.fnamemodify(bufname, ":p"))
+					local expanded_notes_dir = vim.fn.resolve(vim.fn.fnamemodify(notes_dir, ":p"))
+					if resolved_name:sub(1, #expanded_notes_dir) == expanded_notes_dir then
+						vim.wo.wrap = true
+					end
+				end
+			end
+		end,
+	})
+
 	vim.api.nvim_create_autocmd("BufWritePre", {
 		group = group,
 		pattern = { pattern_root, pattern_nested },
@@ -155,6 +177,19 @@ M.setup = function(opts)
 			if config.config.auto_toc then
 				require("notes.toc").update_toc(ev.buf)
 			end
+			pcall(function()
+				require("notes.tablemath").refresh(ev.buf)
+			end)
+		end,
+	})
+
+	vim.api.nvim_create_autocmd("InsertLeave", {
+		group = group,
+		pattern = { pattern_root, pattern_nested },
+		callback = function(ev)
+			pcall(function()
+				require("notes.tablemath").refresh(ev.buf)
+			end)
 		end,
 	})
 

--- a/lua/notes/tablemath.lua
+++ b/lua/notes/tablemath.lua
@@ -1,0 +1,446 @@
+local M = {}
+
+local ns = vim.api.nvim_create_namespace("notes/tablemath")
+
+-- Utility: Convert Excel-style column string to 1-based index (e.g. A->1, B->2, Z->26, AA->27)
+local function col_to_num(col_str)
+	col_str = col_str:upper()
+	local num = 0
+	for i = 1, #col_str do
+		num = num * 26 + (col_str:byte(i) - 64)
+	end
+	return num
+end
+
+-- Utility: Convert 1-based index to Excel-style column string (e.g. 1->A, 2->B)
+local function num_to_col(num)
+	local col = ""
+	while num > 0 do
+		local mod = (num - 1) % 26
+		col = string.char(65 + mod) .. col
+		num = math.floor((num - mod) / 26)
+	end
+	return col
+end
+
+-- Utility: Split table row by | and trim whitespaces from cell values
+local function split_row(line)
+	local s = line:gsub("^%s*|", ""):gsub("|%s*$", "")
+	local cells = {}
+	local last_pos = 1
+	while true do
+		local start_pos, end_pos = string.find(s, "|", last_pos)
+		if not start_pos then
+			table.insert(cells, vim.trim(string.sub(s, last_pos)))
+			break
+		end
+		table.insert(cells, vim.trim(string.sub(s, last_pos, start_pos - 1)))
+		last_pos = end_pos + 1
+	end
+	return cells
+end
+
+-- Lexer/Tokenizer for formula strings
+local function tokenize(expr_str)
+	local tokens = {}
+	local i = 1
+	while i <= #expr_str do
+		local char = expr_str:sub(i, i)
+		if char:match("%s") then
+			i = i + 1
+		elseif char == "(" then
+			table.insert(tokens, { type = "LPAREN", val = "(" })
+			i = i + 1
+		elseif char == ")" then
+			table.insert(tokens, { type = "RPAREN", val = ")" })
+			i = i + 1
+		elseif char == "+" or char == "-" or char == "*" or char == "/" then
+			table.insert(tokens, { type = "OP", val = char })
+			i = i + 1
+		elseif expr_str:sub(i):match("^%a+%d*:%a+%d*") then
+			local range = expr_str:sub(i):match("^%a+%d*:%a+%d*")
+			table.insert(tokens, { type = "RANGE", val = range })
+			i = i + #range
+		elseif expr_str:sub(i):match("^%a+%d+") then
+			local ref = expr_str:sub(i):match("^%a+%d+")
+			table.insert(tokens, { type = "CELL", val = ref })
+			i = i + #ref
+		elseif expr_str:sub(i):match("^%a+") then
+			local name = expr_str:sub(i):match("^%a+")
+			table.insert(tokens, { type = "FUNC", val = name:upper() })
+			i = i + #name
+		elseif expr_str:sub(i):match("^%d+%.?%d*") then
+			local num = expr_str:sub(i):match("^%d+%.?%d*")
+			table.insert(tokens, { type = "NUM", val = tonumber(num) })
+			i = i + #num
+		else
+			error("Unknown token at: " .. char, 0)
+		end
+	end
+	table.insert(tokens, { type = "EOF" })
+	return tokens
+end
+
+-- Recursive descent parser
+local function parse(tokens)
+	local idx = 1
+
+	local function peek()
+		return tokens[idx]
+	end
+
+	local function consume(type)
+		local t = peek()
+		if type and t.type ~= type then
+			error(string.format("Expected token %s, got %s", type, t.type), 0)
+		end
+		idx = idx + 1
+		return t
+	end
+
+	local expression -- forward declaration
+
+	local function factor()
+		local t = peek()
+		if t.type == "NUM" then
+			consume()
+			return { type = "NUM", val = t.val }
+		elseif t.type == "CELL" then
+			consume()
+			return { type = "CELL", val = t.val }
+		elseif t.type == "FUNC" then
+			local func_name = consume().val
+			consume("LPAREN")
+			local arg_token = peek()
+			local arg
+			if arg_token.type == "RANGE" then
+				arg = consume().val
+			elseif arg_token.type == "CELL" then
+				arg = consume().val
+			else
+				error("Expected RANGE or CELL in function call", 0)
+			end
+			consume("RPAREN")
+			return { type = "FUNC", name = func_name, arg = arg }
+		elseif t.type == "LPAREN" then
+			consume()
+			local expr = expression()
+			consume("RPAREN")
+			return expr
+		else
+			error("Unexpected token: " .. tostring(t.type), 0)
+		end
+	end
+
+	local function term()
+		local node = factor()
+		while peek().type == "OP" and (peek().val == "*" or peek().val == "/") do
+			local op = consume().val
+			local right = factor()
+			node = { type = "BINOP", op = op, left = node, right = right }
+		end
+		return node
+	end
+
+	expression = function()
+		local node = term()
+		while peek().type == "OP" and (peek().val == "+" or peek().val == "-") do
+			local op = consume().val
+			local right = term()
+			node = { type = "BINOP", op = op, left = node, right = right }
+		end
+		return node
+	end
+
+	local ast = expression()
+	if peek().type ~= "EOF" then
+		error("Extra tokens after expression", 0)
+	end
+	return ast
+end
+
+local resolve_ref -- forward declaration
+
+-- Evaluate AST node
+local function eval_node(node, tbl, visited)
+	if node.type == "NUM" then
+		return node.val
+	elseif node.type == "CELL" then
+		local val = resolve_ref(tbl, node.val, visited)
+		if type(val) == "string" then
+			local num = tonumber(val)
+			if not num then
+				error("#VALUE!", 0)
+			end
+			return num
+		end
+		return val
+	elseif node.type == "BINOP" then
+		local left = eval_node(node.left, tbl, visited)
+		local right = eval_node(node.right, tbl, visited)
+		if node.op == "+" then
+			return left + right
+		elseif node.op == "-" then
+			return left - right
+		elseif node.op == "*" then
+			return left * right
+		elseif node.op == "/" then
+			if right == 0 then
+				error("#DIV/0!", 0)
+			end
+			return left / right
+		end
+	elseif node.type == "FUNC" then
+		local values = {}
+		if node.arg:find(":") then
+			local start_ref, end_ref = node.arg:match("^([^:]+):([^:]+)$")
+			local start_col, start_row = start_ref:match("^([A-Z]+)(%d+)$")
+			local end_col, end_row = end_ref:match("^([A-Z]+)(%d+)$")
+
+			local sc = col_to_num(start_col)
+			local ec = col_to_num(end_col)
+			local sr = tonumber(start_row)
+			local er = tonumber(end_row)
+
+			if sc > ec then
+				sc, ec = ec, sc
+			end
+			if sr > er then
+				sr, er = er, sr
+			end
+
+			for r = sr, er do
+				for c = sc, ec do
+					local col_name = num_to_col(c)
+					local ref = col_name .. tostring(r)
+					local ok, val = pcall(resolve_ref, tbl, ref, visited)
+					if ok then
+						table.insert(values, val)
+					end
+				end
+			end
+		else
+			local ok, val = pcall(resolve_ref, tbl, node.arg, visited)
+			if ok then
+				table.insert(values, val)
+			end
+		end
+
+		local num_values = {}
+		for _, v in ipairs(values) do
+			local n = tonumber(v)
+			if n then
+				table.insert(num_values, n)
+			end
+		end
+
+		if node.name == "SUM" then
+			local sum = 0
+			for _, v in ipairs(num_values) do
+				sum = sum + v
+			end
+			return sum
+		elseif node.name == "AVG" then
+			if #num_values == 0 then
+				return 0
+			end
+			local sum = 0
+			for _, v in ipairs(num_values) do
+				sum = sum + v
+			end
+			return sum / #num_values
+		elseif node.name == "COUNT" then
+			return #num_values
+		elseif node.name == "MIN" then
+			if #num_values == 0 then
+				return 0
+			end
+			return math.min(unpack(num_values))
+		elseif node.name == "MAX" then
+			if #num_values == 0 then
+				return 0
+			end
+			return math.max(unpack(num_values))
+		else
+			error("Unknown function: " .. tostring(node.name), 0)
+		end
+	end
+end
+
+-- Evaluates formula string
+local function eval_formula(expr_str, tbl, visited)
+	expr_str = expr_str:upper()
+	local tokens = tokenize(expr_str)
+	local ast = parse(tokens)
+	return eval_node(ast, tbl, visited)
+end
+
+-- Resolves reference by looking up the cell and returning its value (caching and resolving formula recursion)
+resolve_ref = function(tbl, cell_ref, visited)
+	if tbl.cache[cell_ref] ~= nil then
+		local status, val = unpack(tbl.cache[cell_ref])
+		if status then
+			return val
+		else
+			error(val, 0)
+		end
+	end
+
+	local col_part, row_part = cell_ref:match("^([A-Z]+)(%d+)$")
+	if not col_part or not row_part then
+		error("#VALUE!", 0)
+	end
+
+	local col_idx = col_to_num(col_part)
+	local row_idx = tonumber(row_part)
+
+	local row = tbl.rows[row_idx]
+	if not row then
+		tbl.cache[cell_ref] = { true, 0 }
+		return 0
+	end
+
+	local cell_str = row.cells[col_idx]
+	if not cell_str or cell_str == "" then
+		tbl.cache[cell_ref] = { true, 0 }
+		return 0
+	end
+
+	if cell_str:sub(1, 1) == "=" then
+		if visited[cell_ref] then
+			error("circular", 0)
+		end
+		visited[cell_ref] = true
+
+		local ok, val = pcall(eval_formula, cell_str:sub(2), tbl, visited)
+		visited[cell_ref] = nil
+
+		if ok then
+			tbl.cache[cell_ref] = { true, val }
+			return val
+		else
+			tbl.cache[cell_ref] = { false, val }
+			error(val, 0)
+		end
+	else
+		tbl.cache[cell_ref] = { true, cell_str }
+		return cell_str
+	end
+end
+
+-- Scans note buffer and identifies valid tables
+local function parse_tables(buf)
+	local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+	local tables = {}
+	local in_table = false
+	local current_table = nil
+
+	for i, line in ipairs(lines) do
+		local has_pipe = string.find(line, "|")
+		if has_pipe then
+			if not in_table then
+				in_table = true
+				current_table = {
+					start_line = i,
+					raw_lines = {},
+				}
+			end
+			table.insert(current_table.raw_lines, { line_num = i, text = line })
+		else
+			if in_table then
+				in_table = false
+				table.insert(tables, current_table)
+				current_table = nil
+			end
+		end
+	end
+	if in_table and current_table then
+		table.insert(tables, current_table)
+	end
+
+	local valid_tables = {}
+	for _, tbl in ipairs(tables) do
+		local sep_idx = nil
+		for idx, row in ipairs(tbl.raw_lines) do
+			local stripped = row.text:gsub("%s", "")
+			if stripped:match("^|?[:%-%|]+|?$") and stripped:find("-") then
+				sep_idx = idx
+				break
+			end
+		end
+
+		if sep_idx then
+			local data_rows = {}
+			for idx = sep_idx + 1, #tbl.raw_lines do
+				local r = tbl.raw_lines[idx]
+				table.insert(data_rows, {
+					line_num = r.line_num,
+					raw = r.text,
+					cells = split_row(r.text),
+				})
+			end
+
+			if #data_rows > 0 then
+				table.insert(valid_tables, {
+					start_line = tbl.start_line,
+					end_line = tbl.start_line + #tbl.raw_lines - 1,
+					rows = data_rows,
+					cache = {},
+				})
+			end
+		end
+	end
+
+	return valid_tables
+end
+
+-- Entry point: refreshes formula calculations and displays virtual text
+M.refresh = function(buf)
+	if not vim.api.nvim_buf_is_valid(buf) then
+		return
+	end
+
+	-- Clear old extmarks
+	vim.api.nvim_buf_clear_namespace(buf, ns, 0, -1)
+
+	local ok, tbls = pcall(parse_tables, buf)
+	if not ok or not tbls then
+		return
+	end
+
+	for _, tbl in ipairs(tbls) do
+		for row_idx, row in ipairs(tbl.rows) do
+			local results = {}
+			for col_idx, cell in ipairs(row.cells) do
+				if cell:sub(1, 1) == "=" then
+					local ref = num_to_col(col_idx) .. tostring(row_idx)
+					local success, val = pcall(resolve_ref, tbl, ref, {})
+					if success then
+						if type(val) == "number" then
+							if val == math.floor(val) then
+								table.insert(results, tostring(val))
+							else
+								table.insert(results, string.format("%.2f", val))
+							end
+						else
+							table.insert(results, tostring(val))
+						end
+					else
+						table.insert(results, "⚠️ " .. tostring(val))
+					end
+				end
+			end
+
+			if #results > 0 then
+				local virt_text = "  │ " .. table.concat(results, " │ ") .. " │"
+				vim.api.nvim_buf_set_extmark(buf, ns, row.line_num - 1, 0, {
+					virt_text = { { virt_text, "Comment" } },
+					virt_text_pos = "eol",
+					hl_mode = "combine",
+				})
+			end
+		end
+	end
+end
+
+return M

--- a/lua/notes/ui.lua
+++ b/lua/notes/ui.lua
@@ -15,6 +15,12 @@ local previewers = require("telescope.previewers")
 local EXPLORER_BUF_NAME = "notes://explorer"
 local copied_note_path = nil
 
+local function attach_markview(bufnr)
+	-- markview.nvim handles its own rendering via autocmds
+	-- This function is kept for backwards compatibility
+end
+M.attach_markview = attach_markview
+
 -- Helper to open a note buffer based on the editor_style setting (current vs float)
 local function open_note_buffer(filepath, target_line)
 	local buf = vim.fn.bufadd(filepath)
@@ -79,6 +85,13 @@ local function open_note_buffer(filepath, target_line)
 
 		local win = vim.api.nvim_open_win(buf, true, win_opts)
 
+		-- Force markview to do a complete render (workaround for partial conceal on first paint)
+		if package.loaded["markview"] then
+			local mv = require("markview").strict_render
+			mv:clear(buf)
+			mv:render(buf)
+		end
+
 		-- Wrap lines and show numbers in the floating note window
 		vim.api.nvim_set_option_value("wrap", true, { win = win })
 		vim.api.nvim_set_option_value("linebreak", true, { win = win })
@@ -87,7 +100,12 @@ local function open_note_buffer(filepath, target_line)
 		vim.api.nvim_set_option_value("relativenumber", false, { win = win })
 
 		-- Buffer-local shortcut 'q' to save and close the float modal
-		vim.keymap.set("n", "q", "<cmd>w<CR><cmd>close<CR>", { buffer = buf, silent = true, desc = "Save and Close Note Float" })
+		vim.keymap.set(
+			"n",
+			"q",
+			"<cmd>w<CR><cmd>close<CR>",
+			{ buffer = buf, silent = true, desc = "Save and Close Note Float" }
+		)
 
 		-- Move to tab
 		vim.keymap.set("n", "<C-g>t", function()
@@ -95,7 +113,12 @@ local function open_note_buffer(filepath, target_line)
 			vim.cmd("close")
 			vim.cmd("tabnew")
 			vim.api.nvim_win_set_buf(0, buf)
-			vim.keymap.set("n", "q", "<cmd>w<CR><cmd>tabclose<CR>", { buffer = buf, silent = true, desc = "Save and Close Note Tab" })
+			vim.keymap.set(
+				"n",
+				"q",
+				"<cmd>w<CR><cmd>tabclose<CR>",
+				{ buffer = buf, silent = true, desc = "Save and Close Note Tab" }
+			)
 		end, { buffer = buf, silent = true, desc = "Move Note from Float to Tab" })
 
 		-- Move to editor (normal buffer)
@@ -108,15 +131,30 @@ local function open_note_buffer(filepath, target_line)
 	elseif config.editor_style == "tab" then
 		vim.cmd("tabnew")
 		vim.api.nvim_win_set_buf(0, buf)
-		vim.keymap.set("n", "q", "<cmd>w<CR><cmd>tabclose<CR>", { buffer = buf, silent = true, desc = "Save and Close Note Tab" })
+		vim.keymap.set(
+			"n",
+			"q",
+			"<cmd>w<CR><cmd>tabclose<CR>",
+			{ buffer = buf, silent = true, desc = "Save and Close Note Tab" }
+		)
 	elseif config.editor_style == "split" then
 		vim.cmd("split")
 		vim.api.nvim_win_set_buf(0, buf)
-		vim.keymap.set("n", "q", "<cmd>w<CR><cmd>close<CR>", { buffer = buf, silent = true, desc = "Save and Close Note Split" })
+		vim.keymap.set(
+			"n",
+			"q",
+			"<cmd>w<CR><cmd>close<CR>",
+			{ buffer = buf, silent = true, desc = "Save and Close Note Split" }
+		)
 	elseif config.editor_style == "vsplit" then
 		vim.cmd("vsplit")
 		vim.api.nvim_win_set_buf(0, buf)
-		vim.keymap.set("n", "q", "<cmd>w<CR><cmd>close<CR>", { buffer = buf, silent = true, desc = "Save and Close Note Split" })
+		vim.keymap.set(
+			"n",
+			"q",
+			"<cmd>w<CR><cmd>close<CR>",
+			{ buffer = buf, silent = true, desc = "Save and Close Note Split" }
+		)
 	else
 		-- Traditional: open in the current window
 		vim.cmd("edit " .. vim.fn.fnameescape(filepath))
@@ -129,22 +167,6 @@ local function open_note_buffer(filepath, target_line)
 		pcall(vim.api.nvim_win_set_cursor, 0, { target_line, 0 })
 	end
 end
-
-
-local months_names = {
-	["01"] = "January",
-	["02"] = "February",
-	["03"] = "March",
-	["04"] = "April",
-	["05"] = "May",
-	["06"] = "June",
-	["07"] = "July",
-	["08"] = "August",
-	["09"] = "September",
-	["10"] = "October",
-	["11"] = "November",
-	["12"] = "December",
-}
 
 -- Function to truncate text and add ellipsis
 local function truncate(text, width)
@@ -226,7 +248,8 @@ local function create_daily_note_at_path(full_path, dir_path, date_str)
 
 	local time = os.date(config.time_format)
 	local title = "Daily Note: " .. date_str
-	local template = (config.daily_template and config.daily_template ~= "") and config.daily_template or config.template
+	local template = (config.daily_template and config.daily_template ~= "") and config.daily_template
+		or config.template
 	template = template:gsub("%%TITLE%%", title)
 	template = template:gsub("%%DATE%%", date_str .. " " .. time)
 	template = template:gsub("tags:%s*%[%s*%]", 'tags: ["daily"]')
@@ -363,6 +386,12 @@ M.new_note = function(title)
 		if desc_line == 0 then
 			desc_line = vim.fn.search("^## Attendees")
 		end
+		if desc_line == 0 then
+			desc_line = vim.fn.search("^## Overview")
+		end
+		if desc_line == 0 then
+			desc_line = vim.fn.search("^## Company Profile")
+		end
 		if desc_line > 0 then
 			pcall(vim.api.nvim_win_set_cursor, 0, { desc_line + 1, 0 })
 		end
@@ -379,25 +408,53 @@ M.new_note = function(title)
 		end
 	end
 
+	local all_templates = {}
 	if config.templates and type(config.templates) == "table" then
-		local keys = {}
-		for k, _ in pairs(config.templates) do
-			table.insert(keys, k)
+		for k, v in pairs(config.templates) do
+			all_templates[k] = { type = "config", content = v }
 		end
-		if config.daily_template and not config.templates.daily then
-			table.insert(keys, "daily")
-		end
-		table.sort(keys)
+	end
+	if config.daily_template and not all_templates.daily then
+		all_templates.daily = { type = "config", content = config.daily_template }
+	end
 
-		local function get_template_content(name)
-			if name == "daily" and not config.templates.daily then
-				return config.daily_template
+	local notes_dir = vim.fn.expand(config.notes_dir):gsub("/+$", "")
+	local templates_dir = notes_dir .. "/templates"
+	if vim.fn.isdirectory(templates_dir) == 1 then
+		local files = vim.fn.globpath(templates_dir, "*.md", false, true)
+		for _, file_path in ipairs(files) do
+			local name = vim.fn.fnamemodify(file_path, ":t:r")
+			all_templates[name] = { type = "file", path = file_path }
+		end
+	end
+
+	local keys = {}
+	for k, _ in pairs(all_templates) do
+		table.insert(keys, k)
+	end
+	table.sort(keys)
+
+	local function get_template_content(name)
+		local t = all_templates[name]
+		if not t then
+			return nil
+		end
+		if t.type == "config" then
+			return t.content
+		elseif t.type == "file" then
+			local f = io.open(t.path, "r")
+			if f then
+				local content = f:read("*all")
+				f:close()
+				return content
 			end
-			return config.templates[name]
 		end
+		return nil
+	end
 
-		if #keys > 1 then
-			pickers.new({}, {
+	if #keys > 1 then
+		pickers
+			.new({}, {
 				prompt_title = "Select Note Template",
 				finder = finders.new_table({
 					results = keys,
@@ -412,6 +469,7 @@ M.new_note = function(title)
 							local lines = vim.split(template_content, "\n")
 							vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, lines)
 							vim.api.nvim_set_option_value("filetype", "markdown", { buf = self.state.bufnr })
+							attach_markview(self.state.bufnr)
 						end
 					end,
 				}),
@@ -426,12 +484,12 @@ M.new_note = function(title)
 					end)
 					return true
 				end,
-			}):find()
-			return
-		elseif #keys == 1 then
-			get_title_and_create(get_template_content(keys[1]))
-			return
-		end
+			})
+			:find()
+		return
+	elseif #keys == 1 then
+		get_title_and_create(get_template_content(keys[1]))
+		return
 	end
 
 	get_title_and_create(config.template)
@@ -493,33 +551,37 @@ end
 
 -- API to list all incomplete tasks across notes
 M.list_tasks = function()
-	local notes = vim.fn.globpath(config.notes_dir, "**/*.md", false, true)
+	local notes_dir = vim.fn.expand(config.notes_dir):gsub("/+$", "")
+	local notes = vim.fn.globpath(notes_dir, "**/*.md", false, true)
 	local tasks = {}
 
 	for _, note_path in ipairs(notes) do
-		local file = io.open(note_path, "r")
-		if file then
-			local lnum = 1
-			local title = vim.fn.fnamemodify(note_path, ":t:r")
-			local metadata = parser.read_file(note_path)
-			if metadata and metadata.title and metadata.title ~= "" then
-				title = metadata.title
-			end
-
-			for line in file:lines() do
-				local task_text = line:match("^%s*%- %[ %]%s*(.*)")
-				if task_text and task_text ~= "" then
-					table.insert(tasks, {
-						path = note_path,
-						title = title,
-						lnum = lnum,
-						text = task_text,
-						line = line,
-					})
+		local rel_path = note_path:sub(#notes_dir + 2):gsub("\\", "/")
+		if rel_path:sub(1, 10) ~= "templates/" then
+			local file = io.open(note_path, "r")
+			if file then
+				local lnum = 1
+				local title = vim.fn.fnamemodify(note_path, ":t:r")
+				local metadata = parser.read_file(note_path)
+				if metadata and metadata.title and metadata.title ~= "" then
+					title = metadata.title
 				end
-				lnum = lnum + 1
+
+				for line in file:lines() do
+					local task_text = line:match("^%s*%- %[ %]%s*(.*)")
+					if task_text and task_text ~= "" then
+						table.insert(tasks, {
+							path = note_path,
+							title = title,
+							lnum = lnum,
+							text = task_text,
+							line = line,
+						})
+					end
+					lnum = lnum + 1
+				end
+				file:close()
 			end
-			file:close()
 		end
 	end
 
@@ -543,36 +605,57 @@ M.list_tasks = function()
 		})
 	end
 
-	pickers.new({}, {
-		prompt_title = "Incomplete Tasks",
-		finder = finders.new_table({
-			results = tasks,
-			entry_maker = function(entry)
-				return {
-					value = entry.path,
-					display = make_display,
-					ordinal = entry.title .. " " .. entry.text,
-					lnum = entry.lnum,
-					col = 1,
-					filename = entry.path,
-					title = entry.title,
-					text = entry.text,
-				}
+	pickers
+		.new({}, {
+			prompt_title = "Incomplete Tasks",
+			finder = finders.new_table({
+				results = tasks,
+				entry_maker = function(entry)
+					return {
+						value = entry.path,
+						display = make_display,
+						ordinal = entry.title .. " " .. entry.text,
+						lnum = entry.lnum,
+						col = 1,
+						filename = entry.path,
+						title = entry.title,
+						text = entry.text,
+					}
+				end,
+			}),
+			sorter = conf.generic_sorter({}),
+			previewer = previewers.new_buffer_previewer({
+				define_preview = function(self, entry, status)
+					local filepath = entry.value
+					if filepath and vim.fn.filereadable(filepath) == 1 then
+						local lines = vim.fn.readfile(filepath)
+						vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, lines)
+						local ext = vim.fn.fnamemodify(filepath, ":e"):lower()
+						if ext == "md" then
+							vim.api.nvim_set_option_value("filetype", "markdown", { buf = self.state.bufnr })
+							if package.loaded["markview"] then
+								vim.schedule(function()
+									local mv = require("markview").strict_render
+									mv:clear(self.state.bufnr)
+									mv:render(self.state.bufnr)
+								end)
+							end
+						end
+					end
+				end,
+			}),
+			attach_mappings = function(prompt_bufnr, map)
+				actions.select_default:replace(function()
+					actions.close(prompt_bufnr)
+					local selection = action_state.get_selected_entry()
+					if selection then
+						open_note_buffer(selection.value, selection.lnum)
+					end
+				end)
+				return true
 			end,
-		}),
-		sorter = conf.generic_sorter({}),
-		previewer = conf.file_previewer({}),
-		attach_mappings = function(prompt_bufnr, map)
-			actions.select_default:replace(function()
-				actions.close(prompt_bufnr)
-				local selection = action_state.get_selected_entry()
-				if selection then
-					open_note_buffer(selection.value, selection.lnum)
-				end
-			end)
-			return true
-		end,
-	}):find()
+		})
+		:find()
 end
 
 --- Built-in omnifunc completion handler for wiki-links
@@ -589,74 +672,87 @@ M.omnifunc = function(findstart, base)
 		end
 		return -1
 	else
-		local notes = vim.fn.globpath(config.notes_dir, "**/*.md", false, true)
+		local notes_dir = vim.fn.expand(config.notes_dir):gsub("/+$", "")
+		local notes = vim.fn.globpath(notes_dir, "**/*.md", false, true)
 		local matches = {}
 		local base_lower = base:lower()
 
 		for _, note_path in ipairs(notes) do
-			local filename = vim.fn.fnamemodify(note_path, ":t:r")
-			local rel_path = note_path:sub(#config.notes_dir + 2):gsub("%.md$", ""):gsub("\\", "/")
-			local is_daily = false
-			local dy, dm, dd = note_path:match("(%d%d%d%d)/(%d%d)/(%d%d)/daily%.md$")
-			if not dy then
-				dy, dm, dd = note_path:match("(%d%d%d%d)%-%(%d%d)%-%(%d%d)%.md$")
-			end
-
-			local metadata = parser.read_file(note_path)
-
-			if dy and dm and dd then
-				is_daily = true
-				local date_str = string.format("%s-%s-%s", dy, dm, dd)
-				local title = (metadata and metadata.title and metadata.title ~= "") and metadata.title or ("Daily Note: " .. date_str)
-
-				-- Suggest by pretty daily title (e.g. "Daily Note: 2026-07-14")
-				if base == "" or title:lower():find(base_lower, 1, true) then
-					table.insert(matches, {
-						word = title .. "]]",
-						abbr = title,
-						menu = "[Daily Note]",
-					})
+			local rel_path = note_path:sub(#notes_dir + 2):gsub("%.md$", ""):gsub("\\", "/")
+			if rel_path:sub(1, 10) ~= "templates/" then
+				local filename = vim.fn.fnamemodify(note_path, ":t:r")
+				local is_daily = false
+				local dy, dm, dd = note_path:match("(%d%d%d%d)/(%d%d)/(%d%d)/daily%.md$")
+				if not dy then
+					dy, dm, dd = note_path:match("(%d%d%d%d)%-%(%d%d)%-%(%d%d)%.md$")
 				end
 
-				-- Suggest by date (e.g. "2026-07-14")
-				if base == "" or date_str:lower():find(base_lower, 1, true) then
-					table.insert(matches, {
-						word = title .. "]]",
-						abbr = date_str,
-						menu = "[Daily Date]",
-					})
-				end
-			else
-				local title = (metadata and metadata.title and metadata.title ~= "") and metadata.title or nil
+				local metadata = parser.read_file(note_path)
 
-				-- 1. Suggest by pretty title
-				if title then
-					if base == "" or title:lower():find(base_lower, 1, true) or filename:lower():find(base_lower, 1, true) or rel_path:lower():find(base_lower, 1, true) then
+				if dy and dm and dd then
+					is_daily = true
+					local date_str = string.format("%s-%s-%s", dy, dm, dd)
+					local title = (metadata and metadata.title and metadata.title ~= "") and metadata.title
+						or ("Daily Note: " .. date_str)
+
+					-- Suggest by pretty daily title (e.g. "Daily Note: 2026-07-14")
+					if base == "" or title:lower():find(base_lower, 1, true) then
 						table.insert(matches, {
 							word = title .. "]]",
 							abbr = title,
-							menu = "[Title]",
+							menu = "[Daily Note]",
 						})
 					end
-				end
 
-				-- 2. Suggest by relative path
-				if base == "" or rel_path:lower():find(base_lower, 1, true) or filename:lower():find(base_lower, 1, true) then
-					table.insert(matches, {
-						word = (title or rel_path) .. "]]",
-						abbr = rel_path,
-						menu = "[Path]",
-					})
-				end
-
-				-- 3. Suggest by filename (if different from rel_path and title)
-				if filename ~= rel_path and (not title or filename ~= title) then
-					if base == "" or filename:lower():find(base_lower, 1, true) then
+					-- Suggest by date (e.g. "2026-07-14")
+					if base == "" or date_str:lower():find(base_lower, 1, true) then
 						table.insert(matches, {
-							word = (title or filename) .. "]]",
-							abbr = filename,
-							menu = "[Note]",
+							word = title .. "]]",
+							abbr = date_str,
+							menu = "[Daily Date]",
 						})
+					end
+				else
+					local title = (metadata and metadata.title and metadata.title ~= "") and metadata.title or nil
+
+					-- 1. Suggest by pretty title
+					if title then
+						if
+							base == ""
+							or title:lower():find(base_lower, 1, true)
+							or filename:lower():find(base_lower, 1, true)
+							or rel_path:lower():find(base_lower, 1, true)
+						then
+							table.insert(matches, {
+								word = title .. "]]",
+								abbr = title,
+								menu = "[Title]",
+							})
+						end
+					end
+
+					-- 2. Suggest by relative path
+					if
+						base == ""
+						or rel_path:lower():find(base_lower, 1, true)
+						or filename:lower():find(base_lower, 1, true)
+					then
+						table.insert(matches, {
+							word = (title or rel_path) .. "]]",
+							abbr = rel_path,
+							menu = "[Path]",
+						})
+					end
+
+					-- 3. Suggest by filename (if different from rel_path and title)
+					if filename ~= rel_path and (not title or filename ~= title) then
+						if base == "" or filename:lower():find(base_lower, 1, true) then
+							table.insert(matches, {
+								word = (title or filename) .. "]]",
+								abbr = filename,
+								menu = "[Note]",
+							})
+						end
 					end
 				end
 			end
@@ -666,10 +762,65 @@ M.omnifunc = function(findstart, base)
 end
 
 -- API to follow wiki-links
+local function open_url(url)
+	-- Validate URL before dispatching
+	local trimmed = vim.trim(url or "")
+	if trimmed == "" then
+		return false
+	end
+
+	local scheme = trimmed:match("^([a-zA-Z][a-zA-Z0-9+%-]*)://")
+	if not scheme then
+		return false
+	end
+
+	if scheme == "file" then
+		-- file:// protocol: open in Neovim
+		local filepath = trimmed:gsub("^file://", "")
+		if vim.fn.filereadable(filepath) == 1 then
+			open_note_buffer(filepath)
+			return true
+		end
+		vim.notify("File not found: " .. filepath, vim.log.levels.WARN)
+		return true
+	end
+
+	-- All other protocols (http, https, ftp, mailto, etc.): open with system handler
+	if vim.ui.open then
+		vim.ui.open(trimmed)
+	else
+		local opener = "xdg-open"
+		if vim.fn.has("macunix") == 1 then
+			opener = "open"
+		elseif vim.fn.has("win32") == 1 or vim.fn.has("win64") == 1 then
+			opener = "start"
+		end
+		vim.fn.jobstart({ opener, trimmed }, { detach = true })
+	end
+	vim.notify("Opening: " .. trimmed, vim.log.levels.INFO)
+	return true
+end
+
 M.follow_wiki_link = function()
 	local line = vim.api.nvim_get_current_line()
 	local col = vim.api.nvim_win_get_cursor(0)[2] + 1
 
+	-- First, check for standard markdown links: [text](url)
+	local md_start = 1
+	while true do
+		local s, e, link_text, link_url = line:find("%[([^%]]-)%]%(([^)]-)%)", md_start)
+		if not s then
+			break
+		end
+		if col >= s and col <= e then
+			if open_url(link_url) then
+				return
+			end
+		end
+		md_start = e + 1
+	end
+
+	-- Then check for wiki-links: [[Link]]
 	local start_idx = 1
 	local link_title = nil
 	while true do
@@ -709,7 +860,8 @@ M.follow_wiki_link = function()
 		if target_daily_path then
 			open_note_buffer(target_daily_path)
 		else
-			local confirm = vim.fn.confirm("Daily Note '" .. link_title .. "' does not exist. Create it?", "&Yes\n&No", 1)
+			local confirm =
+				vim.fn.confirm("Daily Note '" .. link_title .. "' does not exist. Create it?", "&Yes\n&No", 1)
 			if confirm == 1 then
 				local dir_path = string.format("%s/%s/%s/%s", config.notes_dir, yyyy, mm, dd)
 				if vim.fn.isdirectory(dir_path) == 0 then
@@ -736,7 +888,7 @@ M.follow_wiki_link = function()
 	local normalized_link = link_title:gsub("\\", "/"):gsub("^/+", ""):gsub("/+$", "")
 	local sanitized_link = utils.sanitize_title(link_title)
 	local collapsed_sanitized_link = sanitized_link:gsub("-+", "-")
-	
+
 	local notes = vim.fn.globpath(config.notes_dir, "**/*.md", false, true)
 	local target_path = nil
 
@@ -766,10 +918,12 @@ M.follow_wiki_link = function()
 		for _, note in ipairs(notes) do
 			local filename = vim.fn.fnamemodify(note, ":t:r")
 			local collapsed_filename = filename:gsub("-+", "-")
-			if filename:lower() == normalized_link:lower()
+			if
+				filename:lower() == normalized_link:lower()
 				or filename == sanitized_link
 				or collapsed_filename == collapsed_sanitized_link
-				or filename:match("^" .. vim.pesc(sanitized_link) .. "_") then
+				or filename:match("^" .. vim.pesc(sanitized_link) .. "_")
+			then
 				target_path = note
 				break
 			end
@@ -874,7 +1028,26 @@ local function show_notes_picker(prompt_title, results, on_delete_callback)
 				end,
 			}),
 			sorter = conf.generic_sorter({}),
-			previewer = conf.file_previewer({}),
+			previewer = previewers.new_buffer_previewer({
+				define_preview = function(self, entry, status)
+					local filepath = entry.value
+					if filepath and vim.fn.filereadable(filepath) == 1 then
+						local lines = vim.fn.readfile(filepath)
+						vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, lines)
+						local ext = vim.fn.fnamemodify(filepath, ":e"):lower()
+						if ext == "md" then
+							vim.api.nvim_set_option_value("filetype", "markdown", { buf = self.state.bufnr })
+							if package.loaded["markview"] then
+								vim.schedule(function()
+									local mv = require("markview").strict_render
+									mv:clear(self.state.bufnr)
+									mv:render(self.state.bufnr)
+								end)
+							end
+						end
+					end
+				end,
+			}),
 			layout_config = {
 				height = 0.8,
 				width = 0.9,
@@ -919,24 +1092,28 @@ end
 
 -- API to list notes using Telescope
 M.list_notes = function()
-	local notes = vim.fn.globpath(config.notes_dir, "**/*.md", false, true)
+	local notes_dir = vim.fn.expand(config.notes_dir):gsub("/+$", "")
+	local notes = vim.fn.globpath(notes_dir, "**/*.md", false, true)
 	local results = {}
 
 	for _, note_path in ipairs(notes) do
-		local metadata, _ = parser.read_file(note_path)
-		if metadata then
-			local date = metadata.date or ""
-			if date == "" then
-				local mtime = vim.fn.getftime(note_path)
-				date = os.date("%Y-%m-%d %H:%M:%S", mtime)
+		local rel_path = note_path:sub(#notes_dir + 2):gsub("\\", "/")
+		if rel_path:sub(1, 10) ~= "templates/" then
+			local metadata, _ = parser.read_file(note_path)
+			if metadata then
+				local date = metadata.date or ""
+				if date == "" then
+					local mtime = vim.fn.getftime(note_path)
+					date = os.date("%Y-%m-%d %H:%M:%S", mtime)
+				end
+				table.insert(results, {
+					path = note_path,
+					title = metadata.title or vim.fn.fnamemodify(note_path, ":t:r"),
+					date = date,
+					tags = metadata.tags or {},
+					summary = metadata.summary or "",
+				})
 			end
-			table.insert(results, {
-				path = note_path,
-				title = metadata.title or vim.fn.fnamemodify(note_path, ":t:r"),
-				date = date,
-				tags = metadata.tags or {},
-				summary = metadata.summary or "",
-			})
 		end
 	end
 
@@ -949,9 +1126,11 @@ end
 
 -- API to live grep content inside notes
 M.search_notes = function()
+	local notes_dir = vim.fn.expand(config.notes_dir):gsub("/+$", "")
 	require("telescope.builtin").live_grep({
 		prompt_title = "Search Note Contents",
-		search_dirs = { config.notes_dir },
+		search_dirs = { notes_dir },
+		file_ignore_patterns = { "templates/" },
 	})
 end
 
@@ -1040,12 +1219,23 @@ M.render_explorer = function(buf)
 			if not name:match("^%.") then
 				local abs_path = current_dir .. "/" .. name
 				if vim.fn.isdirectory(abs_path) == 1 then
-					table.insert(dirs, { name = name, path = abs_path })
+					local notes_dir = vim.fn.expand(config.notes_dir):gsub("/+$", "")
+					if abs_path ~= notes_dir .. "/templates" then
+						table.insert(dirs, { name = name, path = abs_path })
+					end
 				else
 					local ext = name:match("%.([^%.]+)$")
 					if ext then
 						ext = ext:lower()
-						if ext == "md" or ext == "png" or ext == "jpg" or ext == "jpeg" or ext == "webp" or ext == "gif" or ext == "svg" then
+						if
+							ext == "md"
+							or ext == "png"
+							or ext == "jpg"
+							or ext == "jpeg"
+							or ext == "webp"
+							or ext == "gif"
+							or ext == "svg"
+						then
 							table.insert(files, { name = name, path = abs_path })
 						end
 					end
@@ -1053,8 +1243,12 @@ M.render_explorer = function(buf)
 			end
 		end
 
-		table.sort(dirs, function(a, b) return a.name < b.name end)
-		table.sort(files, function(a, b) return a.name < b.name end)
+		table.sort(dirs, function(a, b)
+			return a.name < b.name
+		end)
+		table.sort(files, function(a, b)
+			return a.name < b.name
+		end)
 
 		-- Render directories
 		for _, d in ipairs(dirs) do
@@ -1072,8 +1266,14 @@ M.render_explorer = function(buf)
 
 			-- Highlight icon and directory name
 			local start_col = #indent
-			table.insert(highlight_actions, { line = line_idx, hl = icon_hl or "Directory", start_col = start_col, end_col = start_col + #icon })
-			table.insert(highlight_actions, { line = line_idx, hl = "Directory", start_col = start_col + #icon, end_col = -1 })
+			table.insert(
+				highlight_actions,
+				{ line = line_idx, hl = icon_hl or "Directory", start_col = start_col, end_col = start_col + #icon }
+			)
+			table.insert(
+				highlight_actions,
+				{ line = line_idx, hl = "Directory", start_col = start_col + #icon, end_col = -1 }
+			)
 
 			if expanded then
 				traverse(d.path, depth + 1)
@@ -1121,8 +1321,14 @@ M.render_explorer = function(buf)
 
 			-- Highlight file
 			local start_col = #indent
-			table.insert(highlight_actions, { line = line_idx, hl = icon_hl, start_col = start_col, end_col = start_col + #icon })
-			table.insert(highlight_actions, { line = line_idx, hl = "Normal", start_col = start_col + #icon, end_col = -1 })
+			table.insert(
+				highlight_actions,
+				{ line = line_idx, hl = icon_hl, start_col = start_col, end_col = start_col + #icon }
+			)
+			table.insert(
+				highlight_actions,
+				{ line = line_idx, hl = "Normal", start_col = start_col + #icon, end_col = -1 }
+			)
 		end
 	end
 
@@ -1260,7 +1466,10 @@ M.bind_explorer_keys = function(buf, line_to_path)
 		local confirm = vim.fn.confirm("Delete " .. type_str .. " '" .. filename .. "'?", "&Yes\n&No", 2)
 		if confirm == 1 then
 			vim.fn.delete(note_path, "rf")
-			vim.notify((is_dir and "Directory" or (type_str:sub(1, 1):upper() .. type_str:sub(2))) .. " deleted: " .. filename, vim.log.levels.INFO)
+			vim.notify(
+				(is_dir and "Directory" or (type_str:sub(1, 1):upper() .. type_str:sub(2))) .. " deleted: " .. filename,
+				vim.log.levels.INFO
+			)
 			M.render_explorer(buf)
 			require("notes.git").commit("delete " .. type_str .. ": " .. filename)
 		end
@@ -1355,7 +1564,9 @@ M.bind_explorer_keys = function(buf, line_to_path)
 				end
 				vim.notify("Note renamed to: " .. new_filename, vim.log.levels.INFO)
 				M.render_explorer(buf)
-				require("notes.git").commit(string.format("rename note: %s -> %s", vim.fn.fnamemodify(note_path, ":t"), new_filename))
+				require("notes.git").commit(
+					string.format("rename note: %s -> %s", vim.fn.fnamemodify(note_path, ":t"), new_filename)
+				)
 			else
 				vim.notify("Failed to rename note file.", vim.log.levels.ERROR)
 			end
@@ -1526,7 +1737,10 @@ M.bind_explorer_keys = function(buf, line_to_path)
 	end
 
 	local function paste_item()
-		if not copied_note_path or (vim.fn.filereadable(copied_note_path) == 0 and vim.fn.isdirectory(copied_note_path) == 0) then
+		if
+			not copied_note_path
+			or (vim.fn.filereadable(copied_note_path) == 0 and vim.fn.isdirectory(copied_note_path) == 0)
+		then
 			vim.notify("No copied file or directory in clipboard register.", vim.log.levels.WARN)
 			return
 		end
@@ -1900,42 +2114,44 @@ M.list_tags = function()
 		},
 	})
 
-	pickers.new({}, {
-		prompt_title = "Tags List",
-		finder = finders.new_table({
-			results = results,
-			entry_maker = function(entry)
-				return {
-					value = entry.tag,
-					display = function(tbl)
-						return displayer({
-							{ "", "Identifier" },
-							{ tbl.tag, "Normal" },
-							{ string.format("(%d notes)", entry.count), "Comment" },
-						})
-					end,
-					ordinal = entry.tag,
-					tag = entry.tag,
-				}
+	pickers
+		.new({}, {
+			prompt_title = "Tags List",
+			finder = finders.new_table({
+				results = results,
+				entry_maker = function(entry)
+					return {
+						value = entry.tag,
+						display = function(tbl)
+							return displayer({
+								{ "", "Identifier" },
+								{ tbl.tag, "Normal" },
+								{ string.format("(%d notes)", entry.count), "Comment" },
+							})
+						end,
+						ordinal = entry.tag,
+						tag = entry.tag,
+					}
+				end,
+			}),
+			sorter = conf.generic_sorter({}),
+			attach_mappings = function(prompt_bufnr, map)
+				actions.select_default:replace(function()
+					actions.close(prompt_bufnr)
+					local selection = action_state.get_selected_entry()
+					if selection then
+						local selected_tag = selection.tag
+						local notes_for_tag = tag_notes[selected_tag] or {}
+						table.sort(notes_for_tag, function(a, b)
+							return (a.date or "") > (b.date or "")
+						end)
+						show_notes_picker("Notes with Tag: " .. selected_tag, notes_for_tag)
+					end
+				end)
+				return true
 			end,
-		}),
-		sorter = conf.generic_sorter({}),
-		attach_mappings = function(prompt_bufnr, map)
-			actions.select_default:replace(function()
-				actions.close(prompt_bufnr)
-				local selection = action_state.get_selected_entry()
-				if selection then
-					local selected_tag = selection.tag
-					local notes_for_tag = tag_notes[selected_tag] or {}
-					table.sort(notes_for_tag, function(a, b)
-						return (a.date or "") > (b.date or "")
-					end)
-					show_notes_picker("Notes with Tag: " .. selected_tag, notes_for_tag)
-				end
-			end)
-			return true
-		end,
-	}):find()
+		})
+		:find()
 end
 
 -- API to find backlinks pointing to the active note buffer
@@ -2292,11 +2508,11 @@ M.insert_toc = function()
 
 	local markers = {
 		"<!-- TOC -->",
-		"<!-- /TOC -->"
+		"<!-- /TOC -->",
 	}
 
 	vim.api.nvim_buf_set_lines(bufnr, row, row, false, markers)
-	
+
 	-- Populate the TOC immediately
 	require("notes.toc").update_toc(bufnr)
 
@@ -2345,45 +2561,48 @@ M.outline = function()
 		})
 	end
 
-	pickers.new({}, {
-		prompt_title = "Document Outline (TOC)",
-		sorting_strategy = "ascending",
-		layout_config = {
-			prompt_position = "top",
-		},
-		finder = finders.new_table({
-			results = headings,
-			entry_maker = function(heading)
-				return {
-					value = heading.lnum,
-					display = make_display,
-					ordinal = heading.text,
-					heading = heading,
-				}
+	pickers
+		.new({}, {
+			prompt_title = "Document Outline (TOC)",
+			sorting_strategy = "ascending",
+			layout_config = {
+				prompt_position = "top",
+			},
+			finder = finders.new_table({
+				results = headings,
+				entry_maker = function(heading)
+					return {
+						value = heading.lnum,
+						display = make_display,
+						ordinal = heading.text,
+						heading = heading,
+					}
+				end,
+			}),
+			sorter = conf.generic_sorter({}),
+			previewer = previewers.new_buffer_previewer({
+				title = "Section Preview",
+				define_preview = function(self, entry, status)
+					local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+					vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, lines)
+					vim.api.nvim_set_option_value("filetype", "markdown", { buf = self.state.bufnr })
+					attach_markview(self.state.bufnr)
+					-- Scroll preview window to the selected heading line
+					pcall(vim.api.nvim_win_set_cursor, self.state.winid, { entry.heading.lnum, 0 })
+				end,
+			}),
+			attach_mappings = function(prompt_bufnr, map)
+				actions.select_default:replace(function()
+					actions.close(prompt_bufnr)
+					local selection = action_state.get_selected_entry()
+					if selection then
+						pcall(vim.api.nvim_win_set_cursor, 0, { selection.value, 0 })
+					end
+				end)
+				return true
 			end,
-		}),
-		sorter = conf.generic_sorter({}),
-		previewer = previewers.new_buffer_previewer({
-			title = "Section Preview",
-			define_preview = function(self, entry, status)
-				local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
-				vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, lines)
-				vim.api.nvim_set_option_value("filetype", "markdown", { buf = self.state.bufnr })
-				-- Scroll preview window to the selected heading line
-				pcall(vim.api.nvim_win_set_cursor, self.state.winid, { entry.heading.lnum, 0 })
-			end,
-		}),
-		attach_mappings = function(prompt_bufnr, map)
-			actions.select_default:replace(function()
-				actions.close(prompt_bufnr)
-				local selection = action_state.get_selected_entry()
-				if selection then
-					pcall(vim.api.nvim_win_set_cursor, 0, { selection.value, 0 })
-				end
-			end)
-			return true
-		end,
-	}):find()
+		})
+		:find()
 end
 
 M.choose_icon = function()
@@ -2485,39 +2704,41 @@ M.choose_icon = function()
 		end
 	end
 
-	pickers.new({}, {
-		prompt_title = "Choose Note Icon",
-		finder = finders.new_table({
-			results = icons_list,
-			entry_maker = function(item)
-				return {
-					value = item,
-					display = make_display,
-					ordinal = item.name,
-				}
-			end,
-		}),
-		sorter = conf.generic_sorter({}),
-		attach_mappings = function(prompt_bufnr, map)
-			actions.select_default:replace(function()
-				actions.close(prompt_bufnr)
-				local selection = action_state.get_selected_entry()
-				if selection then
-					local item = selection.value
-					if item.icon == "CUSTOM" then
-						vim.ui.input({ prompt = "Enter custom icon (emoji or character): " }, function(input)
-							if input and input ~= "" then
-								insert_icon(input)
-							end
-						end)
-					else
-						insert_icon(item.icon)
+	pickers
+		.new({}, {
+			prompt_title = "Choose Note Icon",
+			finder = finders.new_table({
+				results = icons_list,
+				entry_maker = function(item)
+					return {
+						value = item,
+						display = make_display,
+						ordinal = item.name,
+					}
+				end,
+			}),
+			sorter = conf.generic_sorter({}),
+			attach_mappings = function(prompt_bufnr, map)
+				actions.select_default:replace(function()
+					actions.close(prompt_bufnr)
+					local selection = action_state.get_selected_entry()
+					if selection then
+						local item = selection.value
+						if item.icon == "CUSTOM" then
+							vim.ui.input({ prompt = "Enter custom icon (emoji or character): " }, function(input)
+								if input and input ~= "" then
+									insert_icon(input)
+								end
+							end)
+						else
+							insert_icon(item.icon)
+						end
 					end
-				end
-			end)
-			return true
-		end,
-	}):find()
+				end)
+				return true
+			end,
+		})
+		:find()
 end
 
 return M


### PR DESCRIPTION
- Add strict_render clear+render for float notes and Telescope previewers to fix partial markdown conceal on first paint
- Add tablemath.lua: Excel-like formula engine (SUM, AVG, COUNT, MIN, MAX) with virtual text overlay and circular dependency detection
- Add 3 new built-in templates: release, documentation, job_application
- Unify template system: merge file-based (templates/*.md) with config-based
- Exclude templates/ directory from search, explorer, and autocomplete
- Add <leader>nb keymap for backlinks
- Remove dead months_names table and redundant BufWinEnter markview autocmd