### PR TITLE
fix(swap): handle swap recovery and prevent native E325 prompts

### DIFF
--- a/lua/notes/init.lua
+++ b/lua/notes/init.lua
@@ -54,6 +54,18 @@ M.setup = function(opts)
 	-- Apply markview patches if present
 	patch_markview()
 
+	-- Dedicated swap directory for note buffers (keeps .swp files out of notes dir)
+	-- NOTE: 'directory' is a global-only option, so we prepend once at setup
+	if vim.o.swapfile then
+		local swap_dir = vim.fn.stdpath("data") .. "/notes-swap"
+		if vim.fn.isdirectory(swap_dir) == 0 then
+			vim.fn.mkdir(swap_dir, "p")
+		end
+		if not vim.o.directory:find("notes-swap", 1, true) then
+			vim.o.directory = swap_dir .. "//," .. vim.o.directory
+		end
+	end
+
 	-- Expose APIs
 	local ui = safe_require("notes.ui")
 	local utils = safe_require("notes.utils")
@@ -101,12 +113,53 @@ M.setup = function(opts)
 	local pattern_root = notes_dir .. "/*.md"
 	local pattern_nested = notes_dir .. "/**/*.md"
 
+	if vim.o.swapfile then
+		local swap_group = vim.api.nvim_create_augroup("NotesSwapExists", { clear = true })
+		vim.api.nvim_create_autocmd("SwapExists", {
+			group = swap_group,
+			pattern = "*",
+			callback = function(ev)
+				local target_file = vim.fs.normalize(ev.file ~= "" and ev.file or vim.api.nvim_buf_get_name(ev.buf))
+				local norm_notes_dir = vim.fs.normalize(notes_dir)
+
+				if target_file == "" or target_file:sub(1, #norm_notes_dir) ~= norm_notes_dir then
+					return
+				end
+
+				local swapfile = vim.v.swapname
+				if not swapfile or swapfile == "" then
+					return
+				end
+
+				local filename = vim.fn.fnamemodify(target_file ~= "" and target_file or swapfile, ":t")
+				local prompt = string.format("Swap file detected for %s", filename)
+				local choices_str = "&Recover\n&Edit anyway\n&Delete swap\n&Quit"
+				local idx = vim.fn.confirm(prompt, choices_str, 1, "Question")
+
+				if idx == 1 then
+					vim.v.swapchoice = "r"
+				elseif idx == 2 or idx == 3 then
+					if vim.fn.filereadable(swapfile) == 1 then
+						vim.fn.delete(swapfile)
+					end
+					vim.v.swapchoice = "e"
+				else
+					vim.v.swapchoice = "q"
+				end
+			end,
+		})
+	end
+
 	vim.api.nvim_create_autocmd({ "BufRead", "BufNewFile" }, {
 		group = group,
 		pattern = { pattern_root, pattern_nested },
 		callback = function(ev)
 			-- Mark as notes editor buffer
 			vim.b[ev.buf].notes_editor = true
+
+			if vim.o.swapfile then
+				vim.bo[ev.buf].swapfile = true
+			end
 
 			-- Apply/verify markview patches
 			patch_markview()

--- a/lua/notes/ui.lua
+++ b/lua/notes/ui.lua
@@ -21,22 +21,100 @@ local function attach_markview(bufnr)
 end
 M.attach_markview = attach_markview
 
--- Helper to open a note buffer based on the editor_style setting (current vs float)
-local function open_note_buffer(filepath, target_line)
-	local buf = vim.fn.bufadd(filepath)
-	local ext = vim.fn.fnamemodify(filepath, ":e"):lower()
-	if ext ~= "md" then
-		-- For non-markdown assets (like images), if the buffer is already loaded,
-		-- wipe it first so that it is freshly loaded and triggers snacks.image autocommands
-		if vim.api.nvim_buf_is_loaded(buf) then
-			pcall(vim.api.nvim_buf_delete, buf, { force = true })
-			buf = vim.fn.bufadd(filepath)
+-- Compute the Neovim swap filename for a given filepath.
+local function get_swap_filepath(filepath)
+	if not vim.o.swapfile then
+		return nil
+	end
+	local encoded = filepath:gsub("[/\\]", "%%")
+	for _, dir in ipairs(vim.split(vim.o.directory, ",", { plain = true })) do
+		local clean_dir = vim.fs.normalize(dir):gsub("[/\\]+$", "")
+		local swap_name = clean_dir .. "/" .. encoded .. ".swp"
+		if vim.fn.filereadable(swap_name) == 1 then
+			return swap_name
 		end
-		vim.api.nvim_set_option_value("bufhidden", "wipe", { buf = buf })
+	end
+	return nil
+end
+
+-- Checks if a swap file exists for filepath and prompts the user using vim.fn.confirm.
+-- Called upfront in open_note_buffer to avoid low-level bufload E325 errors.
+local function check_swap_recovery(filepath)
+	if not vim.o.swapfile then
+		return "open"
 	end
 
-	vim.fn.bufload(buf)
+	local notes_dir = vim.fs.normalize(config.notes_dir or "")
+	if notes_dir ~= "" and filepath:sub(1, #notes_dir) ~= notes_dir then
+		return "open"
+	end
+
+	local swap_name = get_swap_filepath(filepath)
+	if not swap_name then
+		return "open"
+	end
+
+	local prompt = string.format("Swap file detected for %s", vim.fn.fnamemodify(filepath, ":t"))
+	local choices_str = "&Recover\n&Edit anyway\n&Delete swap\n&Quit"
+	local idx = vim.fn.confirm(prompt, choices_str, 1, "Question")
+
+	if idx == 1 then
+		return "recover"
+	elseif idx == 2 or idx == 3 then
+		vim.fn.delete(swap_name)
+		return "open"
+	else
+		return "quit"
+	end
+end
+
+-- Helper to open a note buffer based on the editor_style setting (current vs float)
+local function open_note_buffer(filepath, target_line)
+	local ext = vim.fn.fnamemodify(filepath, ":e"):lower()
+	local buf
+
+	local swap_action = check_swap_recovery(filepath)
+	if swap_action == "quit" then
+		return
+	end
+
+	if ext ~= "md" then
+		-- Non-markdown assets (e.g. images): force wipe + reload so snacks.image triggers
+		if swap_action == "recover" then
+			vim.cmd("edit " .. vim.fn.fnameescape(filepath))
+			buf = vim.api.nvim_get_current_buf()
+			vim.api.nvim_set_option_value("bufhidden", "wipe", { buf = buf })
+		else
+			buf = vim.fn.bufadd(filepath)
+			if vim.api.nvim_buf_is_loaded(buf) then
+				pcall(vim.api.nvim_buf_delete, buf, { force = true })
+				buf = vim.fn.bufadd(filepath)
+			end
+			vim.api.nvim_set_option_value("bufhidden", "wipe", { buf = buf })
+			vim.fn.bufload(buf)
+		end
+	elseif config.editor_style == "current" then
+		if swap_action == "recover" then
+			vim.cmd("recover " .. vim.fn.fnameescape(filepath))
+		else
+			vim.cmd("edit " .. vim.fn.fnameescape(filepath))
+		end
+		buf = vim.api.nvim_get_current_buf()
+	else
+		-- float/tab/split/vsplit: bypass :edit to avoid wiping the current buffer
+		if swap_action == "recover" then
+			vim.cmd("edit " .. vim.fn.fnameescape(filepath))
+			buf = vim.api.nvim_get_current_buf()
+			pcall(vim.cmd, "recover")
+		else
+			buf = vim.fn.bufadd(filepath)
+			vim.fn.bufload(buf)
+		end
+	end
+
 	vim.b[buf].notes_editor = true
+
+	vim.bo[buf].swapfile = true
 
 	-- Register buffer-local autocommand to enforce wrapping and breakindent options
 	-- whenever the notes buffer is displayed in a window.
@@ -155,9 +233,6 @@ local function open_note_buffer(filepath, target_line)
 			"<cmd>w<CR><cmd>close<CR>",
 			{ buffer = buf, silent = true, desc = "Save and Close Note Split" }
 		)
-	else
-		-- Traditional: open in the current window
-		vim.cmd("edit " .. vim.fn.fnameescape(filepath))
 	end
 
 	vim.bo[buf].omnifunc = "v:lua.require'notes.ui'.omnifunc"


### PR DESCRIPTION
- Respect global vim.o.swapfile setting for swap directory creation and buffer-local swapfile options.
- Intercept low-level buffer loading in open_note_buffer with upfront vim.fn.confirm prompt (Recover, Edit anyway, Delete swap, Quit).
- Automatically remove stale .swp files on Edit anyway and Delete swap to suppress native E325: ATTENTION dialogs.
- Register global SwapExists autocommand with wildcard path matching as a fallback for :edit commands.